### PR TITLE
Fix path to vnu.jar

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var merge = require('merge');
 var PluginError = gutil.PluginError;
-var vnu = 'java -jar ./vnu/vnu.jar ';
+var vnu = 'java -jar ' + __dirname + '/vnu/vnu.jar ';
 
 module.exports = function(opt) {
   var stream  = through.obj(function(file, enc, cb) {


### PR DESCRIPTION
`.` is the directory that the user is calling the task from, `__dirname` is the directory where `index.js` is located.

Fixes #1.