### PR TITLE
Fixes bug in getting resource for validator

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,4 +27,4 @@ gulp.task('ng', function () {
   });
 });
 
-gulp.task('test', ['ok']);
+gulp.task('test', ['ok', 'ng']);

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var merge = require('merge');
 var PluginError = gutil.PluginError;
-var vnu = 'java -jar ' + __dirname + '/vnu/vnu.jar ';
 
 module.exports = function(opt) {
+  var vnu = 'java -jar ' + __dirname + '/vnu/vnu.jar ';
   var stream  = through.obj(function(file, enc, cb) {
     if (file.isNull()) return cb(null, file);
     if (file.isStream()) {


### PR DESCRIPTION
There was a bug to create uncorrect command for exec like the following:
```
java -jar /Users/watilde/Development/gulp-html/vnu/vnu.jar /Users/watilde/Development/gulp-html/test/ok.html
java -jar /Users/watilde/Development/gulp-html/vnu/vnu.jar /Users/watilde/Development/gulp-html/test/ok.html/Users/watilde/Development
```

After merge this PR, I'll publish quickly.